### PR TITLE
Python37 migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ placeholder:
 
 version: 2
 jobs:
-  test_36:
+  test_37:
     docker:
     - image: circleci/python:3.7
       environment:
@@ -94,7 +94,6 @@ workflows:
 
     - submit_coverage:
         requires:
-        - test_36
         - test_37
         - test_flake
         filters:
@@ -103,7 +102,6 @@ workflows:
 
     - distribute:
         requires:
-        - test_36
         - test_37
         - test_flake
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ version: 2
 jobs:
   test_36:
     docker:
-    - image: circleci/python:3.6
+    - image: circleci/python:3.7
       environment:
-        TOXENV=py36
+        TOXENV=py37
     working_directory: ~/repo
     steps:
     # C&P from build_steps
@@ -45,17 +45,9 @@ jobs:
         paths:
         - .coverage
 
-  test_37:
-    docker:
-    - image: circleci/python:3.7
-      environment:
-        TOXENV=py37
-    working_directory: ~/repo
-    steps: *build_steps
-
   test_flake:
     docker:
-    - image: circleci/python:3.6
+    - image: circleci/python:3.7
       environment:
         TOXENV=flake8
     working_directory: ~/repo
@@ -90,11 +82,6 @@ workflows:
   version: 2
   build-distribute:
     jobs:
-    - test_36:
-        filters:
-          tags:
-            only: /.*/ # This is needed so that tags are also built when pushed
-
     - test_37:
         filters:
           tags:

--- a/Pipfile
+++ b/Pipfile
@@ -1,18 +1,14 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
-
 aiohttp = "*"
 click = "*"
-
+asyncio-extras = "*"
 
 [dev-packages]
-
 pylint = "*"
 rope = "*"
 "autopep8" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9738089ab8bcd52aefb0cd077c6267c4fc1e3e9364319a7fe6a965a9a2e327ea"
+            "sha256": "a044ae3942d8cb4b0883f04bca6d2608f14c03338e2b12a35e4ca88cd7f1117c"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -35,12 +35,29 @@
             "index": "pypi",
             "version": "==3.3.2"
         },
+        "async-generator": {
+            "hashes": [
+                "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b",
+                "sha256:6ebb3d106c12920aaae42ccb6f787ef5eefdcdd166ea3d628fa8476abe712144"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.10"
+        },
         "async-timeout": {
             "hashes": [
                 "sha256:474d4bc64cee20603e225eb1ece15e248962958b45a3648a9f5cc29e827a610c",
                 "sha256:b3c0ddc416736619bd4a95ca31de8da6920c3b9a140c64dbef2b2fa7bf521287"
             ],
+            "markers": "python_version >= '3.5.3'",
             "version": "==3.0.0"
+        },
+        "asyncio-extras": {
+            "hashes": [
+                "sha256:084b62bebc19c6ba106d438a274bbb5566941c469128cd4af1a85f00a2c81f8d",
+                "sha256:839568ba07c3470c9aa2c441aa2417c108f7d3755862bc2bd39d69b524303993"
+            ],
+            "index": "pypi",
+            "version": "==1.3.2"
         },
         "attrs": {
             "hashes": [
@@ -93,6 +110,7 @@
                 "sha256:d870f399fcd58a1889e93008762a3b9a27cf7ea512818fc6e689f59495648355",
                 "sha256:e9404e2e19e901121c3c5c6cffd5a8ae0d1d67919c970e3b3262231175713068"
             ],
+            "markers": "python_version >= '3.4.1'",
             "version": "==4.3.1"
         },
         "yarl": {
@@ -107,6 +125,7 @@
                 "sha256:f17495e6fe3d377e3faac68121caef6f974fcb9e046bc075bcff40d8e5cc69a4",
                 "sha256:f85900b9cca0c67767bb61b2b9bd53208aaa7373dae633dbe25d179b4bf38aa7"
             ],
+            "markers": "python_version >= '3.4.1'",
             "version": "==1.2.6"
         }
     },
@@ -116,7 +135,7 @@
                 "sha256:37228cda29411948b422fae072f57e31d3396d2ee1c9783775980ee9c9990af6",
                 "sha256:58587dd4dc3daefad0487f6d9ae32b4542b185e1c36db6993290e7c41ca2b47c"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==1.5"
         },
         "astroid": {
@@ -203,6 +222,7 @@
                 "sha256:e05cb4d9aad6233d67e0541caa7e511fa4047ed7750ec2510d466e806e0255d6",
                 "sha256:f3f501f345f24383c0000395b26b726e46758b71393267aeae0bd36f8b3ade80"
             ],
+            "markers": "python_version >= '2.6' and python_version < '4' and python_version != '3.0.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==4.5.1"
         },
         "coveralls": {
@@ -232,6 +252,7 @@
                 "sha256:a7a84d5fa07a089186a329528f127c9d73b9de57f1a1131b82bb5320ee651f6a",
                 "sha256:fc155a6b553c66c838d1a22dba1dc9f5f505c43285a878c6f74a79c024750b83"
             ],
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==1.5.0"
         },
         "flake8": {
@@ -264,6 +285,7 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==4.3.4"
         },
         "lazy-object-proxy": {
@@ -334,7 +356,7 @@
                 "sha256:6e3836e39f4d36ae72840833db137f7b7d35105079aee6ec4a62d9f80d594dd1",
                 "sha256:95eb8364a4708392bae89035f45341871286a333f749c3141c20573d2b3876e1"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==0.7.1"
         },
         "py": {
@@ -342,7 +364,7 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.1.*' and python_version >= '2.7' and python_version != '3.0.*' and python_version != '3.3.*' and python_version != '3.2.*'",
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==1.5.4"
         },
         "pycodestyle": {
@@ -369,11 +391,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:8214ab8446104a1d0c17fbd218ec6aac743236c6ffbe23abc038e40213c60b88",
-                "sha256:e2b2c6e1560b8f9dc8dd600b0923183fbd68ba3d9bdecde04467be6dd296a384"
+                "sha256:86a8dbf407e437351cef4dba46736e9c5a6e3c3ac71b2e942209748e76ff2086",
+                "sha256:e74466e97ac14582a8188ff4c53e6cc3810315f342f6096899332ae864c1d432"
             ],
             "index": "pypi",
-            "version": "==3.7.0"
+            "version": "==3.7.1"
         },
         "pytest-asyncio": {
             "hashes": [
@@ -396,6 +418,7 @@
                 "sha256:e4500cd0509ec4a26535f7d4112a8cc0f17d3a41c29ffd4eab479d2a55b30805",
                 "sha256:f275cb48a73fc61a6710726348e1da6d68a978f0ec0c54ece5a5fae5977e5a08"
             ],
+            "markers": "python_version != '3.0.*' and python_version >= '2.7' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==0.2"
         },
         "pytest-mock": {
@@ -427,6 +450,7 @@
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version < '4' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==2.19.1"
         },
         "requests-toolbelt": {
@@ -434,7 +458,7 @@
                 "sha256:42c9c170abc2cacb78b8ab23ac957945c7716249206f90874651971a4acff237",
                 "sha256:f6a531936c6fa4c6cfce1b9c10d5c4f498d16528d2a54a22ca00011205a187b5"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version < '4' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*'",
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version < '4' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==0.8.0"
         },
         "restructuredtext-lint": {
@@ -515,6 +539,7 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
+            "markers": "python_version >= '2.6' and python_version != '3.0.*' and python_version < '4' and python_version != '3.3.*' and python_version != '3.1.*' and python_version != '3.2.*'",
             "version": "==1.23"
         },
         "wrapt": {

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
     ],
     packages=find_packages(exclude=['tests']),
     license='MIT',
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     include_package_data=True,
     zip_safe=False,
     keywords=['slack', 'dubtrack', 'bot', 'async', 'asyncio'],

--- a/tests/test_bot.py
+++ b/tests/test_bot.py
@@ -224,7 +224,7 @@ async def test_bot_handle_message(
     if not is_mentioned:
         assert len(asyncio_mock.mock_calls) == 0
     else:
-        command_collection_mock.assert_called_once_with(dummy_bot.message_handlers)
+        command_collection_mock.assert_called_once_with(sources=dummy_bot.message_handlers)
         cmd = command_collection_mock.return_value
         cmd.async_message.assert_called_once_with(m)
         assert len(asyncio_mock.ensure_future.mock_calls) == 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,14 +8,6 @@ import pytest
 from abot import cli
 
 
-def test_stringio_wrapper():
-    m = mock.MagicMock()
-    with cli.stringio_wrapper(m) as fd:
-        fd.write('aaaa')
-
-    m.assert_called_once_with('aaaa')
-
-
 # Integration tests
 
 @pytest.mark.asyncio

--- a/tests/test_dubtrack.py
+++ b/tests/test_dubtrack.py
@@ -105,6 +105,7 @@ async def test_dubtrack_event():
 
     # Test channel can be set
     channel = event.channel = mock.MagicMock()
+    say = channel.say = am.CoroutineMock()
 
     # Test channel has been set
     assert event.channel == channel
@@ -114,7 +115,9 @@ async def test_dubtrack_event():
         event.channel = channel
 
     # Assert reply can be called
-    assert None is await event.reply('something', 'someone')
+    await event.reply('something', 'someone')
+    channel.say.assert_awaited_once_with('someone: something')
+    say.reset_mock()
 
     # Working __repr__
     assert repr(event)


### PR DESCRIPTION
There is a need for us to provide the event to the commands, so that we can start implementing permissions in the bots, however this is not possible in any other way but through the use of the new python3.7 module `contextvars`.

This PR drops support for 3.6, bumps dependencies and fixes command execution.