### PR TITLE
Ensure that error always shows the latest class name

### DIFF
--- a/abot/bot.py
+++ b/abot/bot.py
@@ -59,7 +59,7 @@ class BotObject:
     def bot(self) -> 'Bot':
         if hasattr(self, '_bot'):
             return self._bot
-        raise ValueError('Bot is not set in BotObject')
+        raise ValueError(f'Bot is not set in {self.__class__.__name__}')
 
     @bot.setter
     def bot(self, bot: 'Bot'):


### PR DESCRIPTION
Interpolate the class name instead of using a hardcoded string. With this change, if the class is renamed, the change will need to be made only in 1 place.